### PR TITLE
Add basic README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# libplacebo-rs
+
+[libplacebo](https://github.com/haasn/libplacebo) bindings for Rust.
+
+## License
+
+Copyright 2019 The [Rust AV](https://github.com/rust-av) Contributors. Released under the [MIT License](LICENSE).


### PR DESCRIPTION
I thought the project would be a bit friendlier if it had a `README`, even if it doesn't offer much information at this point.