### PR TITLE
Change the name of the package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "libplacebo-rs"
+name = "libplacebo"
 version = "0.1.0"
 authors = ["Luca Barbato <lu_zero@gentoo.org>"]
 edition = "2018"


### PR DESCRIPTION
I think it's better `libplacebo` than `libplacebo-rs` for the crate.

Thanks!